### PR TITLE
Fix: Correctly encode Trello card comments

### DIFF
--- a/src/trello/client.ts
+++ b/src/trello/client.ts
@@ -451,7 +451,7 @@ export class TrelloClient {
       `/cards/${cardId}/actions/comments`,
       {
         method: 'POST',
-        params: { text: encodeURIComponent(text) }
+        body: JSON.stringify({ text })
       },
       `Add comment to card ${cardId}`
     );


### PR DESCRIPTION
This PR fixes an issue where comments added to Trello cards were not being correctly encoded, leading to potential display issues or API errors.

The change modifies the `trello_add_comment` function in `src/trello/client.ts` to use `body: JSON.stringify({ text })` instead of `params: { text: encodeURIComponent(text) }`. This ensures that the comment text is sent as a JSON body, which is the correct way to send data for POST requests to the Trello API.

**Example:**
Before this fix, a comment containing special characters (e.g., `&`, `#`, `?`) might not be displayed correctly on Trello. After this fix, such comments will be handled properly.