### PR TITLE
Fix: Use stderr for logging instead of stdout

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -51,7 +51,8 @@ class Logger {
       ...(context && { context })
     };
 
-    console.log(JSON.stringify(logEntry));
+    // MCP servers must use stderr for logging, stdout is reserved for JSON-RPC
+    console.error(JSON.stringify(logEntry));
   }
 
   debug(message: string, context?: LogContext) {


### PR DESCRIPTION
## Problem
The MCP server was generating validation errors when the logger was active:
```
Invalid literal value, expected "2.0"
Unrecognized key(s) in object: 'timestamp', 'level', 'message', 'context'
```

## Root Cause
The logger was writing log entries to **stdout** using `console.log()`, but the MCP protocol requires that:
- **stdout** is reserved exclusively for JSON-RPC messages
- **stderr** should be used for logging and debugging output

When log entries were written to stdout, they were incorrectly interpreted as malformed JSON-RPC messages, causing Zod validation errors.

## Solution
Changed the logger to use `console.error()` instead of `console.log()` in `src/utils/logger.ts`. This ensures that:
- Log entries are correctly written to stderr
- stdout remains clean for JSON-RPC communication
- The MCP server works correctly even when logging is enabled

## Testing
- Tested with Claude Desktop and confirmed that the validation errors no longer occur
- The server now functions correctly with logging enabled
- No impact on the existing `MCP_DESKTOP_MODE` environment variable feature

## Changes
- Modified `src/utils/logger.ts` line 54-55
- Added explanatory comment about MCP logging requirements

This is a small but critical fix for MCP protocol compliance.