### PR TITLE
docs: rebrand from Claude Desktop-specific to MCP client-agnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Trello MCP is a Model Context Protocol server providing Trello integration for any MCP-compatible client (Claude Desktop, Claude Code, Gemini CLI, etc.). It runs as a local stdio process, communicating via JSON-RPC over stdout. Credentials (`TRELLO_API_KEY`, `TRELLO_TOKEN`) are injected from environment variables at startup.
+
+## Build & Development Commands
+
+```bash
+npm run build          # Compile TypeScript → dist/
+npm run clean          # Remove dist/
+npm run rebuild        # Clean + build
+npm run type-check     # TypeScript check without emitting
+```
+
+There is no test runner, linter, or formatter configured. Validate changes with `npm run type-check`.
+
+## Architecture
+
+### Entry Point & Protocol
+
+`src/index.ts` is the MCP server entry point. It reads credentials from env vars, registers 19 tools, and routes `CallToolRequest` to handler functions via a switch statement. Credentials are automatically injected into every tool handler call. **No console output is allowed** — stdout is reserved for JSON-RPC.
+
+### Tool Modules
+
+Each file in `src/tools/` exports two things per tool: a **tool definition** (schema object) and a **handler function**. Tools are organized in phases:
+
+| Module | Tools | Domain |
+|--------|-------|--------|
+| `search.ts` | `trello_search` | Universal search |
+| `boards.ts` | `trello_get_user_boards`, `get_board_details`, `list_boards`, `get_lists` | Board operations (last two are legacy) |
+| `cards.ts` | `get_card`, `create_card`, `update_card`, `move_card` | Card CRUD |
+| `lists.ts` | `trello_get_list_cards`, `trello_create_list`, `trello_add_comment` | List ops & comments |
+| `members.ts` | `trello_get_member` + user boards handler | Member info |
+| `advanced.ts` | Board cards, card actions/attachments/checklists, board members/labels | Extended features |
+
+### Trello API Client
+
+`src/trello/client.ts` wraps all Trello REST API calls with:
+- Exponential backoff retry (3 attempts)
+- 15-second request timeout via AbortController
+- Rate limit header handling
+- Typed error classification (network, auth, permissions, rate limit)
+
+### Validation
+
+`src/utils/validation.ts` uses Zod schemas to validate all tool inputs at runtime. Every handler validates its arguments before calling the API client.
+
+### Type System
+
+`src/types/trello.ts` defines all domain interfaces (`TrelloBoard`, `TrelloCard`, `TrelloList`, etc.) and request/response types (`CreateCardRequest`, `UpdateCardRequest`, `MoveCardRequest`).
+
+## Key Conventions
+
+- **ESM modules** — the project uses `"type": "module"` with `.js` extensions in imports (even for TypeScript sources)
+- **Strict TypeScript** — `strict: true` plus `noUnusedLocals`, `noUnusedParameters`, `exactOptionalPropertyTypes`, `verbatimModuleSyntax`
+- **Tool pattern** — when adding a new tool: define the schema object + handler in the appropriate `src/tools/` file, then register both in `src/index.ts` (add to `ListToolsRequestSchema` array and `CallToolRequestSchema` switch)
+- **Credential injection** — handlers receive credentials via `argsWithCredentials`, never access env vars directly
+- **No stdout logging** — use `src/utils/logger.ts` which is disabled when `MCP_DESKTOP_MODE` is set
+
+## Adding a New Tool
+
+1. Create or update a file in `src/tools/` with the tool definition (MCP schema) and handler function
+2. Add Zod validation schema in `src/utils/validation.ts`
+3. Import and register in `src/index.ts`: add to the tools array in `ListToolsRequestSchema` handler and add a case in the `CallToolRequestSchema` switch
+4. Add any new types to `src/types/trello.ts`
+5. Run `npm run type-check` to verify

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Trello Desktop MCP
+# Trello MCP
 
-A Model Context Protocol (MCP) server that provides comprehensive Trello integration for Claude Desktop. This server enables Claude to interact with Trello boards, cards, lists, and more through a secure local connection.
+A Model Context Protocol (MCP) server that provides comprehensive Trello integration for any MCP-compatible client — including Claude Desktop, Claude Code, Gemini CLI, and more. This server enables AI assistants to interact with Trello boards, cards, lists, and more through a secure local connection.
 
 ## Features
 
@@ -30,7 +30,7 @@ A Model Context Protocol (MCP) server that provides comprehensive Trello integra
 
 ### Prerequisites
 - Node.js 18+ installed
-- Claude Desktop application
+- An MCP-compatible client (Claude Desktop, Claude Code, Gemini CLI, etc.)
 - Trello account with API credentials
 
 ### Setup Steps
@@ -56,11 +56,17 @@ A Model Context Protocol (MCP) server that provides comprehensive Trello integra
    - Copy your API Key
    - Generate a Token (never expires, read/write access)
 
-5. **Configure Claude Desktop**
-   
+5. **Configure your MCP client**
+
+   Choose the instructions for your client below:
+
+   <details>
+   <summary><strong>Claude Desktop</strong></summary>
+
    Edit your Claude Desktop configuration file:
    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
    - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+   - Linux: `~/.config/Claude/claude_desktop_config.json`
 
    Add the Trello MCP server:
    ```json
@@ -78,7 +84,67 @@ A Model Context Protocol (MCP) server that provides comprehensive Trello integra
    }
    ```
 
-6. **Restart Claude Desktop**
+   Then restart Claude Desktop.
+   </details>
+
+   <details>
+   <summary><strong>Claude Code (CLI)</strong></summary>
+
+   Add the server using the Claude Code CLI:
+   ```bash
+   claude mcp add trello -- node /absolute/path/to/trello-desktop-mcp/dist/index.js \
+     -e TRELLO_API_KEY=your-api-key-here \
+     -e TRELLO_TOKEN=your-token-here
+   ```
+
+   Or add it to your project's `.mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "trello": {
+         "command": "node",
+         "args": ["/absolute/path/to/trello-desktop-mcp/dist/index.js"],
+         "env": {
+           "TRELLO_API_KEY": "your-api-key-here",
+           "TRELLO_TOKEN": "your-token-here"
+         }
+       }
+     }
+   }
+   ```
+   </details>
+
+   <details>
+   <summary><strong>Gemini CLI</strong></summary>
+
+   Edit your Gemini CLI settings file at `~/.gemini/settings.json`:
+   ```json
+   {
+     "mcpServers": {
+       "trello": {
+         "command": "node",
+         "args": ["/absolute/path/to/trello-desktop-mcp/dist/index.js"],
+         "env": {
+           "TRELLO_API_KEY": "your-api-key-here",
+           "TRELLO_TOKEN": "your-token-here"
+         }
+       }
+     }
+   }
+   ```
+   </details>
+
+   <details>
+   <summary><strong>Other MCP Clients</strong></summary>
+
+   Any MCP-compatible client that supports stdio transport can use this server. You need to configure it to:
+   1. Run `node /absolute/path/to/trello-desktop-mcp/dist/index.js`
+   2. Set environment variables `TRELLO_API_KEY` and `TRELLO_TOKEN`
+
+   Refer to your client's documentation for the exact configuration format.
+   </details>
+
+6. **Restart your MCP client** to pick up the new configuration.
 
 ## Available Tools
 
@@ -113,7 +179,7 @@ The MCP server provides 19 tools organized into three phases:
 
 ## Usage Examples
 
-Once configured, you can use natural language with Claude to interact with Trello:
+Once configured, you can use natural language with your AI assistant to interact with Trello:
 
 ```
 "Show me all my Trello boards"
@@ -134,7 +200,7 @@ The server implements the Model Context Protocol (MCP), which provides:
 - Automatic credential management
 
 ### Security
-- API credentials are stored locally in Claude Desktop's config
+- API credentials are stored locally in your MCP client's config
 - No credentials are transmitted over the network
 - All Trello API calls use HTTPS
 - Rate limiting is respected with automatic retry logic
@@ -150,7 +216,7 @@ The server implements the Model Context Protocol (MCP), which provides:
 ### Project Structure
 ```
 ├── src/
-│   ├── index.ts          # Main entry point for Claude Desktop
+│   ├── index.ts          # Main MCP server entry point
 │   ├── server.ts         # Alternative server implementation
 │   ├── tools/            # Tool implementations
 │   │   ├── boards.ts     # Board-related tools
@@ -181,7 +247,7 @@ npm run type-check
 
 ### Testing
 The server includes comprehensive error handling and validation. Test your setup by:
-1. Checking Claude Desktop's MCP connection status
+1. Checking your MCP client's connection status
 2. Running a simple command like "Show me my Trello boards"
 3. Verifying the response includes your board data
 
@@ -190,7 +256,7 @@ The server includes comprehensive error handling and validation. Test your setup
 ### Common Issues
 
 1. **"No Trello tools available"**
-   - Ensure Claude Desktop is fully restarted after configuration
+   - Ensure your MCP client is fully restarted after configuration
    - Check that the path in config points to `dist/index.js`
    - Verify the file exists and is built
 
@@ -205,7 +271,7 @@ The server includes comprehensive error handling and validation. Test your setup
    - Consider reducing request frequency
 
 ### Debug Logging
-Check MCP logs at:
+Check your MCP client's logs for connection and error details. For Claude Desktop, logs are at:
 - macOS: `~/Library/Logs/Claude/mcp-server-trello.log`
 - Windows: `%APPDATA%\Claude\Logs\mcp-server-trello.log`
 
@@ -225,4 +291,4 @@ MIT License - see LICENSE file for details
 
 - Built with the [Model Context Protocol SDK](https://github.com/anthropics/mcp)
 - Uses the [Trello REST API](https://developer.atlassian.com/cloud/trello/rest/)
-- Designed for [Claude Desktop](https://claude.ai/download)
+- Compatible with [Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and other MCP clients

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "trello-desktop-mcp",
+  "name": "trello-mcp",
   "version": "1.0.0",
-  "description": "Trello integration for Claude Desktop via Model Context Protocol (MCP)",
+  "description": "Trello integration for any MCP-compatible client via Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
@@ -16,13 +16,14 @@
     "model-context-protocol",
     "trello",
     "claude",
-    "claude-desktop",
+    "gemini",
+    "ai-assistant",
     "api",
     "integration",
     "productivity",
     "project-management"
   ],
-  "author": "Trello Desktop MCP Contributors",
+  "author": "Trello MCP Contributors",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   ListPromptsRequestSchema 
 } from '@modelcontextprotocol/sdk/types.js';
 
-// Desktop-specific: Check for local credentials
+// Read credentials from environment variables
 const TRELLO_API_KEY = process.env.TRELLO_API_KEY;
 const TRELLO_TOKEN = process.env.TRELLO_TOKEN;
 
@@ -79,7 +79,7 @@ import {
 // Create server instance
 const server = new Server(
   {
-    name: 'trello-mcp-desktop',
+    name: 'trello-mcp',
     version: '1.0.0',
   },
   {
@@ -101,7 +101,7 @@ server.setRequestHandler(InitializeRequestSchema, async () => {
       prompts: {}
     },
     serverInfo: {
-      name: 'trello-mcp-desktop',
+      name: 'trello-mcp',
       version: '1.0.0'
     }
   };

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,23 +1,51 @@
 # Configuration Reference
 
-This guide provides comprehensive configuration options and settings for Trello Desktop MCP.
+This guide provides comprehensive configuration options and settings for Trello MCP.
 
 ## Basic Configuration
 
-### Claude Desktop Configuration
+### MCP Client Configuration
 
-The primary configuration for Trello Desktop MCP is done through Claude Desktop's MCP configuration file.
+Trello MCP works with any MCP-compatible client. Below are configuration paths and formats for popular clients.
 
 #### Configuration File Locations
 
-| Platform | Configuration File Path |
-|----------|------------------------|
-| **macOS** | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| **Windows** | `%APPDATA%\Claude\claude_desktop_config.json` |
-| **Linux** | `~/.config/Claude/claude_desktop_config.json` |
+| Client | Platform | Configuration File Path |
+|--------|----------|------------------------|
+| **Claude Desktop** | macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| **Claude Desktop** | Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| **Claude Desktop** | Linux | `~/.config/Claude/claude_desktop_config.json` |
+| **Claude Code** | All | Project `.mcp.json` or via `claude mcp add` CLI |
+| **Gemini CLI** | All | `~/.gemini/settings.json` |
 
-#### Basic Configuration Structure
+#### Claude Desktop Configuration
 
+```json
+{
+  "mcpServers": {
+    "trello": {
+      "command": "node",
+      "args": ["/absolute/path/to/trello-desktop-mcp/dist/index.js"],
+      "env": {
+        "TRELLO_API_KEY": "your-api-key-here",
+        "TRELLO_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
+```
+
+#### Claude Code CLI
+
+```bash
+claude mcp add trello -- node /absolute/path/to/trello-desktop-mcp/dist/index.js \
+  -e TRELLO_API_KEY=your-api-key-here \
+  -e TRELLO_TOKEN=your-token-here
+```
+
+#### Gemini CLI Configuration
+
+Edit `~/.gemini/settings.json`:
 ```json
 {
   "mcpServers": {
@@ -84,7 +112,7 @@ The primary configuration for Trello Desktop MCP is done through Claude Desktop'
 
 1. On the same page, click the **Token** link next to "To read a user's private information and to update, create and delete a user's boards and organizations."
 2. Authorize the application with these settings:
-   - **Application Name**: Trello Desktop MCP
+   - **Application Name**: Trello MCP
    - **Scope**: Read and Write
    - **Expiration**: Never (recommended for personal use)
 3. Copy the generated token (64+ character string)
@@ -100,7 +128,7 @@ Your token should have these permissions:
 ### Security Considerations
 
 - **Never commit credentials to version control**
-- **Store credentials only in Claude Desktop config**
+- **Store credentials only in your MCP client's config**
 - **Regenerate tokens if they may have been exposed**
 - **Use tokens with minimal required permissions**
 - **Consider token expiration for shared systems**

--- a/wiki/Installation-Guide.md
+++ b/wiki/Installation-Guide.md
@@ -1,13 +1,13 @@
 # Installation Guide
 
-This guide will walk you through setting up Trello Desktop MCP with Claude Desktop.
+This guide will walk you through setting up Trello MCP with your MCP-compatible client.
 
 ## Prerequisites
 
 Before you begin, ensure you have:
 
 - **Node.js 18+** installed on your system
-- **Claude Desktop** application installed
+- An **MCP-compatible client** (Claude Desktop, Claude Code, Gemini CLI, etc.)
 - An active **Trello account** with API access
 - Basic familiarity with command line operations
 
@@ -32,7 +32,7 @@ npm install
 npm run build
 ```
 
-This creates the compiled JavaScript files in the `dist/` directory that Claude Desktop will use.
+This creates the compiled JavaScript files in the `dist/` directory that your MCP client will use.
 
 ## Step 2: Obtain Trello API Credentials
 
@@ -52,19 +52,19 @@ This creates the compiled JavaScript files in the `dist/` directory that Claude 
 
 > **Security Note**: Your API credentials provide full access to your Trello account. Keep them secure and never share them publicly.
 
-## Step 3: Configure Claude Desktop
+## Step 3: Configure Your MCP Client
 
-### 3.1 Locate Configuration File
+Choose the instructions for your client below.
 
-Find your Claude Desktop configuration file:
+### 3.1 Claude Desktop
+
+Locate your configuration file:
 
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
-### 3.2 Add MCP Server Configuration
-
-Edit the configuration file and add the Trello MCP server:
+Add the Trello MCP server:
 
 ```json
 {
@@ -81,42 +81,54 @@ Edit the configuration file and add the Trello MCP server:
 }
 ```
 
-**Important Configuration Notes**:
+### 3.2 Claude Code (CLI)
 
-1. **Use Absolute Paths**: Replace `/absolute/path/to/trello-desktop-mcp/dist/index.js` with the full path to your installation
-2. **Replace Credentials**: Insert your actual API key and token from Step 2
-3. **JSON Format**: Ensure proper JSON formatting with no trailing commas
+```bash
+claude mcp add trello -- node /absolute/path/to/trello-desktop-mcp/dist/index.js \
+  -e TRELLO_API_KEY=your-api-key-here \
+  -e TRELLO_TOKEN=your-token-here
+```
 
-### 3.3 Example Configuration
+### 3.3 Gemini CLI
 
-Here's a complete example configuration:
+Edit `~/.gemini/settings.json`:
 
 ```json
 {
   "mcpServers": {
     "trello": {
-      "command": "node", 
-      "args": ["/Users/username/Projects/trello-desktop-mcp/dist/index.js"],
+      "command": "node",
+      "args": ["/absolute/path/to/trello-desktop-mcp/dist/index.js"],
       "env": {
-        "TRELLO_API_KEY": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
-        "TRELLO_TOKEN": "x1y2z3a4b5c6d7e8f9g0h1i2j3k4l5m6n7o8p9q0r1s2t3u4v5w6x7y8z9a0b1c2d3e4f5g6h7i8j9k0"
+        "TRELLO_API_KEY": "your-api-key-here",
+        "TRELLO_TOKEN": "your-token-here"
       }
     }
   }
 }
 ```
 
-## Step 4: Restart Claude Desktop
+### 3.4 Other MCP Clients
 
-1. **Completely quit** Claude Desktop (not just close the window)
-2. **Restart** Claude Desktop
+Any client supporting MCP stdio transport can use this server. Configure it to run `node /absolute/path/to/trello-desktop-mcp/dist/index.js` with environment variables `TRELLO_API_KEY` and `TRELLO_TOKEN`.
+
+**Important Configuration Notes**:
+
+1. **Use Absolute Paths**: Replace `/absolute/path/to/trello-desktop-mcp/dist/index.js` with the full path to your installation
+2. **Replace Credentials**: Insert your actual API key and token from Step 2
+3. **JSON Format**: Ensure proper JSON formatting with no trailing commas
+
+## Step 4: Restart Your MCP Client
+
+1. **Completely quit** your MCP client (not just close the window)
+2. **Restart** it
 3. Wait for the application to fully load
 
 ## Step 5: Verify Installation
 
 ### 5.1 Test Basic Connectivity
 
-In Claude Desktop, try these commands to verify the installation:
+In your MCP client, try these commands to verify the installation:
 
 ```
 Show me my Trello boards
@@ -142,7 +154,7 @@ You should see all 20 Trello tools listed and organized by category.
 
 1. **Path Issue**: Verify the path to `dist/index.js` is absolute and correct
 2. **Build Issue**: Run `npm run build` again to ensure the dist folder exists
-3. **Restart Required**: Completely restart Claude Desktop
+3. **Restart Required**: Completely restart your MCP client
 4. **File Permissions**: Ensure Node.js can read the files
 
 ### Issue: "Invalid credentials" 
@@ -177,9 +189,9 @@ You should see all 20 Trello tools listed and organized by category.
 - [ ] Repository cloned and dependencies installed
 - [ ] Project built successfully (`dist/` folder exists)
 - [ ] Trello API key and token obtained
-- [ ] Claude Desktop configuration file updated
+- [ ] MCP client configuration file updated
 - [ ] Absolute paths used in configuration
-- [ ] Claude Desktop completely restarted
+- [ ] MCP client completely restarted
 - [ ] Basic Trello commands working
 
 ## Next Steps
@@ -195,7 +207,7 @@ Once installation is complete:
 If you encounter issues:
 
 1. Check the [Troubleshooting Guide](Troubleshooting)
-2. Review Claude Desktop's MCP logs
+2. Review your MCP client's logs
 3. [Open an issue](https://github.com/yourusername/trello-desktop-mcp/issues) with detailed error information
 
 ---


### PR DESCRIPTION
## Summary
- Rebrands project from "Trello Desktop MCP" (Claude Desktop-only) to "Trello MCP" (any MCP client)
- Adds multi-client configuration docs for **Claude Desktop**, **Claude Code CLI**, **Gemini CLI**, and generic MCP clients
- Updates server name in code (`trello-mcp-desktop` → `trello-mcp`), package metadata, and all documentation

## Changes
| File | What changed |
|------|-------------|
| `src/index.ts` | Server name `trello-mcp-desktop` → `trello-mcp`, comment update |
| `package.json` | Name, description, keywords, author |
| `README.md` | Multi-client setup with collapsible `<details>` sections |
| `CLAUDE.md` | Project description updated |
| `wiki/Configuration.md` | Multi-client config table, Claude Code & Gemini CLI sections |
| `wiki/Installation-Guide.md` | Generalized all client-specific references |

## Not changed (deferred)
- `MCP_DESKTOP_MODE` env var in `logger.ts` — breaking change, separate PR
- Other wiki pages (Troubleshooting, Architecture, Security) — separate follow-up
- GitHub repo name — would break existing links

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [ ] Visually review README `<details>` rendering on GitHub

Closes #3, closes #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily documentation/metadata updates plus a server `name` string rename, with no changes to tool behavior or API interactions.
> 
> **Overview**
> Rebrands the project from *Claude Desktop-specific* to a *generic MCP-client* Trello server, updating docs to describe usage with Claude Desktop, Claude Code, Gemini CLI, and other stdio MCP clients.
> 
> Updates runtime identifiers/metadata by renaming the MCP server `name` (`trello-mcp-desktop` → `trello-mcp`) in `src/index.ts` and adjusting `package.json` package name/description/keywords/author accordingly, plus adds a new `CLAUDE.md` contributor guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 454f6ae1a49cfb24264cb0b5b57e2db83a935cac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->