### PR TITLE
feat: image attachment downloads & checklist tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,10 @@ import {
   handleTrelloGetCardAttachments,
   trelloGetCardChecklistsTool,
   handleTrelloGetCardChecklists,
+  trelloCreateChecklistTool,
+  handleTrelloCreateChecklist,
+  trelloAddCheckItemTool,
+  handleTrelloAddCheckItem,
   trelloGetBoardMembersTool,
   handleTrelloGetBoardMembers,
   trelloGetBoardLabelsTool,
@@ -133,6 +137,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       trelloGetCardActionsTool,
       trelloGetCardAttachmentsTool,
       trelloGetCardChecklistsTool,
+      trelloCreateChecklistTool,
+      trelloAddCheckItemTool,
       trelloGetBoardMembersTool,
       trelloGetBoardLabelsTool
     ]
@@ -226,7 +232,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'trello_get_card_checklists':
         result = await handleTrelloGetCardChecklists(argsWithCredentials);
         break;
-      
+
+      case 'trello_create_checklist':
+        result = await handleTrelloCreateChecklist(argsWithCredentials);
+        break;
+
+      case 'trello_add_check_item':
+        result = await handleTrelloAddCheckItem(argsWithCredentials);
+        break;
+
       case 'trello_get_board_members':
         result = await handleTrelloGetBoardMembers(argsWithCredentials);
         break;

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,10 @@ import {
   handleTrelloGetCardAttachments,
   trelloGetCardChecklistsTool,
   handleTrelloGetCardChecklists,
+  trelloCreateChecklistTool,
+  handleTrelloCreateChecklist,
+  trelloAddCheckItemTool,
+  handleTrelloAddCheckItem,
   trelloGetBoardMembersTool,
   handleTrelloGetBoardMembers,
   trelloGetBoardLabelsTool,
@@ -115,6 +119,8 @@ export function createMCPServer() {
         trelloGetCardActionsTool,
         trelloGetCardAttachmentsTool,
         trelloGetCardChecklistsTool,
+        trelloCreateChecklistTool,
+        trelloAddCheckItemTool,
         trelloGetBoardMembersTool,
         trelloGetBoardLabelsTool
       ],
@@ -194,7 +200,13 @@ export function createMCPServer() {
       
       case 'trello_get_card_checklists':
         return await handleTrelloGetCardChecklists(args);
-      
+
+      case 'trello_create_checklist':
+        return await handleTrelloCreateChecklist(args);
+
+      case 'trello_add_check_item':
+        return await handleTrelloAddCheckItem(args);
+
       case 'trello_get_board_members':
         return await handleTrelloGetBoardMembers(args);
       

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -51,6 +51,28 @@ const validateGetCardChecklists = (args: unknown) => {
   return schema.parse(args);
 };
 
+const validateCreateChecklist = (args: unknown) => {
+  const schema = z.object({
+    apiKey: z.string().min(1, 'API key is required'),
+    token: z.string().min(1, 'Token is required'),
+    cardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid card ID format'),
+    name: z.string().min(1, 'Checklist name is required')
+  });
+
+  return schema.parse(args);
+};
+
+const validateAddCheckItem = (args: unknown) => {
+  const schema = z.object({
+    apiKey: z.string().min(1, 'API key is required'),
+    token: z.string().min(1, 'Token is required'),
+    checklistId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid checklist ID format'),
+    name: z.string().min(1, 'Check item name is required')
+  });
+
+  return schema.parse(args);
+};
+
 const validateGetBoardMembers = (args: unknown) => {
   const schema = z.object({
     apiKey: z.string().min(1, 'API key is required'),
@@ -462,6 +484,154 @@ export async function handleTrelloGetCardChecklists(args: unknown) {
         {
           type: 'text' as const,
           text: `Error getting card checklists: ${errorMessage}`
+        }
+      ],
+      isError: true
+    };
+  }
+}
+
+export const trelloCreateChecklistTool: Tool = {
+  name: 'trello_create_checklist',
+  description: 'Create a new checklist on a Trello card. Use this to add a testing checklist or task list to a card.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      apiKey: {
+        type: 'string',
+        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
+      },
+      token: {
+        type: 'string',
+        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
+      },
+      cardId: {
+        type: 'string',
+        description: 'ID of the card to add the checklist to',
+        pattern: '^[a-f0-9]{24}$'
+      },
+      name: {
+        type: 'string',
+        description: 'Name of the checklist (e.g., "Testing Steps")'
+      }
+    },
+    required: ['apiKey', 'token', 'cardId', 'name']
+  }
+};
+
+export async function handleTrelloCreateChecklist(args: unknown) {
+  try {
+    const { apiKey, token, cardId, name } = validateCreateChecklist(args);
+    const client = new TrelloClient({ apiKey, token });
+
+    const response = await client.createChecklist(cardId, name);
+    const checklist = response.data;
+
+    const result = {
+      summary: `Created checklist "${checklist.name}" on card`,
+      checklist: {
+        id: checklist.id,
+        name: checklist.name,
+        cardId: checklist.idCard,
+        boardId: checklist.idBoard
+      },
+      rateLimit: response.rateLimit
+    };
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2)
+        }
+      ]
+    };
+  } catch (error) {
+    const errorMessage = error instanceof z.ZodError
+      ? formatValidationError(error)
+      : error instanceof Error
+        ? error.message
+        : 'Unknown error occurred';
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error creating checklist: ${errorMessage}`
+        }
+      ],
+      isError: true
+    };
+  }
+}
+
+export const trelloAddCheckItemTool: Tool = {
+  name: 'trello_add_check_item',
+  description: 'Add an item to a Trello checklist. Use this to add individual steps to a checklist on a card.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      apiKey: {
+        type: 'string',
+        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
+      },
+      token: {
+        type: 'string',
+        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
+      },
+      checklistId: {
+        type: 'string',
+        description: 'ID of the checklist to add the item to (you can get this from trello_create_checklist or trello_get_card_checklists)',
+        pattern: '^[a-f0-9]{24}$'
+      },
+      name: {
+        type: 'string',
+        description: 'Text for the check item (e.g., "Open the report page and check the heading is centred")'
+      }
+    },
+    required: ['apiKey', 'token', 'checklistId', 'name']
+  }
+};
+
+export async function handleTrelloAddCheckItem(args: unknown) {
+  try {
+    const { apiKey, token, checklistId, name } = validateAddCheckItem(args);
+    const client = new TrelloClient({ apiKey, token });
+
+    const response = await client.addCheckItem(checklistId, name);
+    const item = response.data;
+
+    const result = {
+      summary: `Added check item: "${item.name}"`,
+      checkItem: {
+        id: item.id,
+        name: item.name,
+        state: item.state,
+        checklistId: item.idChecklist
+      },
+      rateLimit: response.rateLimit
+    };
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2)
+        }
+      ]
+    };
+  } catch (error) {
+    const errorMessage = error instanceof z.ZodError
+      ? formatValidationError(error)
+      : error instanceof Error
+        ? error.message
+        : 'Unknown error occurred';
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error adding check item: ${errorMessage}`
         }
       ],
       isError: true

--- a/src/tools/cards.ts
+++ b/src/tools/cards.ts
@@ -360,14 +360,27 @@ export const getCardTool: Tool = {
   }
 };
 
+const IMAGE_MIME_TYPES = new Set([
+  'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml', 'image/bmp'
+]);
+
 export async function handleGetCard(args: unknown) {
   try {
     const { apiKey, token, cardId, includeDetails } = validateGetCard(args);
-    
+
     const client = new TrelloClient({ apiKey, token });
-    const response = await client.getCard(cardId, includeDetails);
+    const [response, attachmentsResponse] = await Promise.all([
+      client.getCard(cardId, includeDetails),
+      client.getCardAttachments(cardId)
+    ]);
     const card = response.data;
-    
+    const attachments = attachmentsResponse.data;
+
+    // Identify image attachments
+    const imageAttachments = attachments.filter(
+      (a: any) => a.mimeType && IMAGE_MIME_TYPES.has(a.mimeType)
+    );
+
     const result = {
       summary: `Card: ${card.name}`,
       card: {
@@ -382,6 +395,13 @@ export async function handleGetCard(args: unknown) {
         dueComplete: card.dueComplete,
         closed: card.closed,
         lastActivity: card.dateLastActivity,
+        attachments: attachments.map((a: any) => ({
+          id: a.id,
+          name: a.name,
+          url: a.url,
+          mimeType: a.mimeType,
+          isImage: IMAGE_MIME_TYPES.has(a.mimeType || '')
+        })),
         ...(includeDetails && {
           labels: card.labels?.map(label => ({
             id: label.id,
@@ -416,22 +436,51 @@ export async function handleGetCard(args: unknown) {
       },
       rateLimit: response.rateLimit
     };
-    
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(result, null, 2)
+
+    const content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result, null, 2)
+      }
+    ];
+
+    // Download and include image attachments as image content blocks
+    const downloadResults: string[] = [];
+    if (imageAttachments.length > 0) {
+      const downloads = await Promise.all(
+        imageAttachments.map((a: any) => client.downloadAttachment(a.url))
+      );
+
+      for (let i = 0; i < imageAttachments.length; i++) {
+        const downloaded = downloads[i];
+        const attachment = imageAttachments[i];
+        if (downloaded) {
+          content.push({
+            type: 'image' as const,
+            data: downloaded.data,
+            mimeType: downloaded.mimeType
+          });
+          downloadResults.push(`✓ ${attachment.name}: ${downloaded.mimeType}, ${Math.round(downloaded.data.length * 3/4 / 1024)}KB`);
+        } else {
+          downloadResults.push(`✗ ${attachment.name}: download failed (url: ${attachment.url})`);
         }
-      ]
-    };
+      }
+    }
+
+    // Append download status to the text block
+    if (downloadResults.length > 0) {
+      result.summary += `\n\nImage downloads (${downloadResults.filter(r => r.startsWith('✓')).length}/${downloadResults.length} succeeded):\n${downloadResults.join('\n')}`;
+    }
+    (content[0] as { type: 'text'; text: string }).text = JSON.stringify(result, null, 2);
+
+    return { content };
   } catch (error) {
-    const errorMessage = error instanceof z.ZodError 
+    const errorMessage = error instanceof z.ZodError
       ? formatValidationError(error)
-      : error instanceof Error 
-        ? error.message 
+      : error instanceof Error
+        ? error.message
         : 'Unknown error occurred';
-        
+
     return {
       content: [
         {

--- a/src/trello/client.ts
+++ b/src/trello/client.ts
@@ -360,12 +360,37 @@ export class TrelloClient {
       params.checklists = 'all';
       params.badges = 'true';
     }
-    
+
     return this.makeRequest<TrelloCard>(
       `/cards/${cardId}`,
       { params },
       `Get card ${cardId}`
     );
+  }
+
+  async downloadAttachment(url: string): Promise<{ data: string; mimeType: string } | null> {
+    try {
+      const response = await this.fetchWithTimeout(url, {
+        timeout: 30000,
+        headers: {
+          'Authorization': `OAuth oauth_consumer_key="${this.credentials.apiKey}", oauth_token="${this.credentials.token}"`
+        }
+      });
+      if (!response.ok) {
+        logger.warn(`Attachment download failed: ${response.status} ${response.statusText}`, { url });
+        return null;
+      }
+
+      const contentType = response.headers.get('content-type') || 'application/octet-stream';
+      const buffer = await response.arrayBuffer();
+      const base64 = Buffer.from(buffer).toString('base64');
+
+      logger.info(`Downloaded attachment: ${contentType}, ${buffer.byteLength} bytes`);
+      return { data: base64, mimeType: contentType };
+    } catch (error) {
+      logger.error(`Attachment download error`, { url, error: error instanceof Error ? error.message : String(error) });
+      return null;
+    }
   }
 
   async deleteCard(cardId: string): Promise<TrelloApiResponse<void>> {
@@ -561,6 +586,28 @@ export class TrelloClient {
       `/cards/${cardId}/attachments`,
       { params },
       `Get attachments for card ${cardId}`
+    );
+  }
+
+  async createChecklist(cardId: string, name: string): Promise<TrelloApiResponse<any>> {
+    return this.makeRequest<any>(
+      `/cards/${cardId}/checklists`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ name })
+      },
+      `Create checklist "${name}" on card ${cardId}`
+    );
+  }
+
+  async addCheckItem(checklistId: string, name: string): Promise<TrelloApiResponse<any>> {
+    return this.makeRequest<any>(
+      `/checklists/${checklistId}/checkItems`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ name })
+      },
+      `Add check item to checklist ${checklistId}`
     );
   }
 


### PR DESCRIPTION
## Summary
- **Image attachments in get_card**: When `get_card` is called, the server now automatically downloads image attachments and returns them as inline MCP image content blocks, so agents can see screenshots and photos directly
- **New tools**: `trello_create_checklist` and `trello_add_check_item` for managing checklists on cards

## Image attachment details
- Uses OAuth header authentication for Trello attachment download endpoints (query param auth returns 401 on download URLs)
- Supports PNG, JPEG, GIF, WebP, SVG, and BMP formats
- Downloads happen in parallel with card detail fetching
- Failures are handled gracefully — card data is still returned even if image downloads fail
- Includes download status summary in the text response

## Checklist tools
- `trello_create_checklist`: Create a named checklist on a card
- `trello_add_check_item`: Add an item to an existing checklist by checklist ID
- Both registered in `index.ts` (stdio) and `server.ts` (factory) entry points
- Zod validation for all inputs